### PR TITLE
fix: use production API endpoint in tsup config

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33708,7 +33708,7 @@ var getMiddlewareOptions = async (apiToken, debug3 = () => {
   const url2 = new URL(
     `/v1/appwarden/config`,
     // @ts-expect-error tsup config
-    "https://staging-api.appwarden.io"
+    "https://api.appwarden.io"
   );
   debug3(`[config] Request URL: ${url2.toString()}`);
   debug3(

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(async () => {
     noExternal: [/(.*)/],
     define: {
       MIDDLEWARE_VERSION: v(middlewareVersion),
-      APPWARDEN_API_HOSTNAME: v("https://staging-api.appwarden.io"),
+      APPWARDEN_API_HOSTNAME: v("https://api.appwarden.io"),
     },
   }
 })


### PR DESCRIPTION
Fixes the failing release pipeline by switching the injected APPWARDEN_API_HOSTNAME from the staging endpoint to the production endpoint in tsup.config.ts.
