### PR TITLE
chore(deps): group all dependency updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,24 +6,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
     commit-message:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
     groups:
-      dev-dependencies:
+      all-dependencies:
         patterns:
-          - "@types/*"
-          - "@vitest/*"
-          - "typescript"
-          - "vitest"
-          - "prettier"
-          - "tsup"
-          - "lefthook"
-        update-types:
-          - "minor"
-          - "patch"
+          - "*"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -31,9 +22,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     commit-message:
       prefix: "chore(deps)"
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      all-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This improves the Dependabot configuration so each ecosystem opens a single combined PR instead of many individual ones.

Changes:
- Replaced the npm `dev-dependencies` group with a catch-all `all-dependencies` group that includes every npm package (prod, dev, and major updates).
- Added a catch-all `all-actions` group for the GitHub Actions ecosystem.
- Reduced `open-pull-requests-limit` to `1` for both ecosystems, since the groups now combine everything into one PR each.

With this config, Dependabot will produce at most one npm PR and one GitHub Actions PR per week.